### PR TITLE
Deprecate yielder.concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Deprecated `yielder.concat` function. Use `yielder.flatten` instead.
+
 ## v1.1.0 - 2024-11-29
 
 - Added `yielder.prepend` function.

--- a/src/gleam/yielder.gleam
+++ b/src/gleam/yielder.gleam
@@ -501,6 +501,7 @@ fn flatten_loop(flattened: fn() -> Action(Yielder(a))) -> Action(a) {
 /// // -> [1, 2, 3, 4]
 /// ```
 ///
+@deprecated("Use `yielder.flatten` instead.")
 pub fn concat(yielders: List(Yielder(a))) -> Yielder(a) {
   flatten(from_list(yielders))
 }


### PR DESCRIPTION
`yielder` seems to mostly follow the interface of `list`. We deprecated `list.concact` in favor of `list.flatten`, in Gleam's spirit of only having one way to do things. Feels like we should do the same thing here.

Reference:

- https://github.com/gleam-lang/stdlib/issues/707
- https://github.com/gleam-lang/stdlib/pull/710