### PR TITLE
Deprecate yielder.prepend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Deprecated `yielder.prepend` function. Use `yielder.push_front` instead.
+
 ## v1.1.0 - 2024-11-29
 
 - Added `yielder.prepend` function.

--- a/src/gleam/yielder.gleam
+++ b/src/gleam/yielder.gleam
@@ -1609,8 +1609,8 @@ pub fn each(over yielder: Yielder(a), with f: fn(a) -> b) -> Nil {
 /// This function is for use with `use` expressions, to replicate the behaviour
 /// of the `yield` keyword found in other languages.
 ///
-/// If you only need to prepend an element and don't require the `use` syntax,
-/// use `prepend`.
+/// If you only need to add an element to the beginning of a yielder and don't
+/// require the `use` syntax, use `push_front`.
 ///
 /// ## Examples
 ///
@@ -1641,7 +1641,24 @@ pub fn yield(element: a, next: fn() -> Yielder(a)) -> Yielder(a) {
 /// // -> [0, 1, 2, 3]
 /// ```
 ///
+@deprecated("Use `yielder.push_front` instead.")
 pub fn prepend(yielder: Yielder(a), element: a) -> Yielder(a) {
+  use <- yield(element)
+  yielder
+}
+
+/// Add a new element to the start of a yielder.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let yielder = from_list([1, 2, 3]) |> push_front(0)
+///
+/// yielder.to_list
+/// // -> [0, 1, 2, 3]
+/// ```
+///
+pub fn push_front(yielder: Yielder(a), element: a) -> Yielder(a) {
   use <- yield(element)
   yielder
 }

--- a/test/gleam_yielder_test.gleam
+++ b/test/gleam_yielder_test.gleam
@@ -742,3 +742,10 @@ pub fn prepend_test() {
   |> yielder.to_list
   |> should.equal([0, 1, 2, 3])
 }
+
+pub fn push_front_test() {
+  yielder.from_list([1, 2, 3])
+  |> yielder.push_front(0)
+  |> yielder.to_list
+  |> should.equal([0, 1, 2, 3])
+}


### PR DESCRIPTION
I think we might've made a mistake with #1, as we now have `yielder.prepend` and `yielder.append`, but `yielder.prepend` takes in a single element and `yielder.prepend .append` takes in another `yielder` of elements. Seems like those functions should have the same inputs, and it is confusing that they don't. My proposal is to rename this to `yielder.push_front`, to match the same nomenclature used in other gleam libs, such as `deque`, to avoid confusion.

https://hexdocs.pm/gleam_deque/gleam/deque.html#push_front

(I wouldn't normally open a PR without talking about it first, but this one and #4 are so small that I'm ok with them being throwaways if not wanted).